### PR TITLE
Adds env variable for specifying password file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The proxy is configured via environment variables.
   If set, SSL will be used.
 * `SSL_CRT` — A path to an SSL certificate.
   Must be set if `SSL_KEY` is set.
+* `SSL_PASSWORD_FILE` - A path to a password file used for validating certificate.
 * `AUTO_SSL` — If set, a self-signed SSL certificate will be generated and used.
 * `LOG` — A location to write request logs to.
   See below for further documentation on logging.

--- a/run.sh
+++ b/run.sh
@@ -53,9 +53,15 @@ if [ $AUTO_SSL ]; then
 fi
 
 if [ $SSL_KEY ]; then
+  if [ $SSL_PASSWORD_FILE ]; then
+    PASSWORD_FILE="ssl_password_file $SSL_PASSWORD_FILE;"
+  else
+    PASSWORD_FILE=""
+  fi
 	BIND="listen 8000 ssl http2;
 	ssl_certificate $SSL_CRT;
 	ssl_certificate_key $SSL_KEY;
+	$PASSWORD_FILE
 	ssl_session_timeout 1d;
 	ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
 	ssl_session_tickets off;


### PR DESCRIPTION
openssl will generate certs/keys with a password and there was no previous method for passing one in (and configuring nginx).